### PR TITLE
Create command line option for parameter files.

### DIFF
--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -39,7 +39,7 @@ parser.add_argument(
 
 parser.add_argument(
     "--parameter_file",
-    type=Path,
+    type=str,
     default=None,
     help="relative path to parameter file to use for this run",
 )
@@ -54,7 +54,6 @@ else:
     from gains.params.single_spin_up_rotating import parameters
 
     PARAMS = parameters
-
 
 PARAMS["use_checkpoint"] = args["use_checkpoint"]
 PARAMS["checkpoint_path"] = args["checkpoint_path"]

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -2,9 +2,9 @@
 
 import argparse
 import datetime
+import json
 import logging
 from pathlib import Path
-import json
 
 import dedalus.public as d3
 import numpy as np
@@ -40,17 +40,17 @@ parser.add_argument(
 
 parser.add_argument(
     "--parameter_file",
-    type=str,
+    type=Path,
     default=None,
-    help="relative path to parameter file to use for this run",
+    help="relative path to parameter file to use for this run, saved in json format.",
 )
 
 args = vars(parser.parse_args())
 
 if args["parameter_file"] is not None:
-    with open(args["parameter_file"], "r") as param_file:
+    with Path.open(args["parameter_file"]) as param_file:
         PARAMS = json.load(param_file)
-    
+
 else:
     PARAMS = default_params
 

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime
 import logging
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 import dedalus.public as d3
@@ -11,7 +12,6 @@ from mpi4py import MPI
 
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
-from gains.params.single_spin_up_rotating import parameters
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +37,25 @@ parser.add_argument(
     "--output_dir", type=str, default=None, help="Directory to store simulation outputs"
 )
 
+parser.add_argument(
+    "--parameter_file",
+    type=Path,
+    default=None,
+    help="relative path to parameter file to use for this run",
+)
+
 args = vars(parser.parse_args())
 
-PARAMS = parameters
+if args["parameter_file"] is not None:
+    param_path = args["parameter_file"]
+    param_file = SourceFileLoader("param_file", param_path).load_module()
+    PARAMS = param_file.parameters
+else:
+    from gains.params.single_spin_up_rotating import parameters
+
+    PARAMS = parameters
+
+
 PARAMS["use_checkpoint"] = args["use_checkpoint"]
 PARAMS["checkpoint_path"] = args["checkpoint_path"]
 PARAMS["output_dir"] = (

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -3,8 +3,8 @@
 import argparse
 import datetime
 import logging
-from importlib.machinery import SourceFileLoader
 from pathlib import Path
+import json
 
 import dedalus.public as d3
 import numpy as np
@@ -48,9 +48,9 @@ parser.add_argument(
 args = vars(parser.parse_args())
 
 if args["parameter_file"] is not None:
-    param_path = args["parameter_file"]
-    param_file = SourceFileLoader("param_file", param_path).load_module()
-    PARAMS = param_file.parameters
+    with open(args["parameter_file"], "r") as param_file:
+        PARAMS = json.load(param_file)
+    
 else:
     PARAMS = default_params
 

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -12,6 +12,7 @@ from mpi4py import MPI
 
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
+from gains.params.single_spin_up_rotating import parameters as default_params
 
 logger = logging.getLogger(__name__)
 
@@ -51,9 +52,7 @@ if args["parameter_file"] is not None:
     param_file = SourceFileLoader("param_file", param_path).load_module()
     PARAMS = param_file.parameters
 else:
-    from gains.params.single_spin_up_rotating import parameters
-
-    PARAMS = parameters
+    PARAMS = default_params
 
 PARAMS["use_checkpoint"] = args["use_checkpoint"]
 PARAMS["checkpoint_path"] = args["checkpoint_path"]


### PR DESCRIPTION
Fixes #38 by providing additional command line option for parameter files. The file takes the same format of storing parameters in a dictionary, which is added to the script using the `importlib` library. If no parameter file is provided the script defaults to the one in `src/gains/params` and runs as it did before.