### PR TITLE
Rmcshane/mesh warn

### DIFF
--- a/scripts/kelvin_helmholtz.py
+++ b/scripts/kelvin_helmholtz.py
@@ -103,7 +103,7 @@ log2 = np.log2(ncpu)
 if log2 == int(log2):
     mesh = [ncpu]
 else:
-    raise (MeshError)
+    raise MeshError
 
 logger.info(f"running on processor mesh={mesh}")
 

--- a/scripts/kelvin_helmholtz.py
+++ b/scripts/kelvin_helmholtz.py
@@ -19,6 +19,7 @@ import dedalus.public as d3
 import numpy as np
 from mpi4py import MPI
 
+from gains.exceptions import MeshError
 from gains.initial_conditions.mcnally import density, velocity_x
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,9 @@ log2 = np.log2(ncpu)
 
 if log2 == int(log2):
     mesh = [ncpu]
+else:
+    raise (MeshError)
+
 logger.info(f"running on processor mesh={mesh}")
 
 rho_m = (PARAMS["rho_1"] - PARAMS["rho_2"]) / 2

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -1,6 +1,8 @@
 """Simulates the spin up of a full sphere containing a viscous newtonian fluid."""
 
 import argparse
+import warnings
+import sys
 import datetime
 import json
 import logging
@@ -13,6 +15,14 @@ from mpi4py import MPI
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
 from gains.params.single_spin_up_rotating import parameters as default_params
+
+class MeshError(Exception):
+    """Exception for negative values in instances they should be positive."""
+
+    def __init__(self) -> None:
+        """Error message."""
+        super().__init__("Number of cpus should be a power of 2")
+
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +83,9 @@ log2 = np.log2(ncpu)
 
 if log2 == int(log2):
     mesh = [int(2 ** np.ceil(log2 / 2)), int(2 ** np.floor(log2 / 2))]
+else:
+    raise(MeshError)
+
 logger.info(f"running on processor mesh={mesh}")
 
 

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -1,8 +1,6 @@
 """Simulates the spin up of a full sphere containing a viscous newtonian fluid."""
 
 import argparse
-import warnings
-import sys
 import datetime
 import json
 import logging
@@ -15,6 +13,7 @@ from mpi4py import MPI
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
 from gains.params.single_spin_up_rotating import parameters as default_params
+
 
 class MeshError(Exception):
     """Exception for negative values in instances they should be positive."""
@@ -84,7 +83,7 @@ log2 = np.log2(ncpu)
 if log2 == int(log2):
     mesh = [int(2 ** np.ceil(log2 / 2)), int(2 ** np.floor(log2 / 2))]
 else:
-    raise(MeshError)
+    raise (MeshError)
 
 logger.info(f"running on processor mesh={mesh}")
 

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -13,14 +13,7 @@ from mpi4py import MPI
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
 from gains.params.single_spin_up_rotating import parameters as default_params
-
-
-class MeshError(Exception):
-    """Exception for negative values in instances they should be positive."""
-
-    def __init__(self) -> None:
-        """Error message."""
-        super().__init__("Number of cpus should be a power of 2")
+from gains.exceptions import MeshError
 
 
 logger = logging.getLogger(__name__)

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -76,7 +76,7 @@ log2 = np.log2(ncpu)
 if log2 == int(log2):
     mesh = [int(2 ** np.ceil(log2 / 2)), int(2 ** np.floor(log2 / 2))]
 else:
-    raise (MeshError)
+    raise MeshError
 
 logger.info(f"running on processor mesh={mesh}")
 

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -10,11 +10,11 @@ import dedalus.public as d3
 import numpy as np
 from mpi4py import MPI
 
+from gains.exceptions import MeshError
+
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
 from gains.params.single_spin_up_rotating import parameters as default_params
-from gains.exceptions import MeshError
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/gains/exceptions.py
+++ b/src/gains/exceptions.py
@@ -2,7 +2,7 @@
 
 
 class MeshError(Exception):
-    """Exception for negative values in instances they should be positive."""
+    """Exception raised if the number of cpus given is not a power of 2"""
 
     def __init__(self) -> None:
         """Error message."""

--- a/src/gains/exceptions.py
+++ b/src/gains/exceptions.py
@@ -1,5 +1,6 @@
 """Holds custom exceptions used in the package."""
 
+
 class MeshError(Exception):
     """Exception for negative values in instances they should be positive."""
 

--- a/src/gains/exceptions.py
+++ b/src/gains/exceptions.py
@@ -1,0 +1,16 @@
+"""Holds custom exceptions used in the package."""
+
+class MeshError(Exception):
+    """Exception for negative values in instances they should be positive."""
+
+    def __init__(self) -> None:
+        """Error message."""
+        super().__init__("Number of cpus should be a power of 2")
+
+
+class ExpectPositiveError(Exception):
+    """Exception for negative values in instances they should be positive."""
+
+    def __init__(self, var: str | float) -> None:
+        """:param var: The variable that should be positive."""
+        super().__init__(f"{var} should be positive.")

--- a/src/gains/exceptions.py
+++ b/src/gains/exceptions.py
@@ -2,11 +2,11 @@
 
 
 class MeshError(Exception):
-    """Exception raised if the number of cpus given is not a power of 2"""
+    """Exception raised if the number of cpus given is not a power of 2."""
 
     def __init__(self) -> None:
         """Error message."""
-        super().__init__("Number of cpus should be a power of 2")
+        super().__init__("Number of cpus should be a power of 2.")
 
 
 class ExpectPositiveError(Exception):

--- a/src/gains/initial_conditions/single_component_spin_up.py
+++ b/src/gains/initial_conditions/single_component_spin_up.py
@@ -7,7 +7,9 @@ specific parts of the boundary of a sphere.
 """
 
 import numpy as np
+
 from gains.exceptions import ExpectPositiveError
+
 
 def window_equator(theta: np.ndarray, width: float, dtype: type) -> np.ndarray:
     """

--- a/src/gains/initial_conditions/single_component_spin_up.py
+++ b/src/gains/initial_conditions/single_component_spin_up.py
@@ -7,15 +7,7 @@ specific parts of the boundary of a sphere.
 """
 
 import numpy as np
-
-
-class ExpectPositiveError(Exception):
-    """Exception for negative values in instances they should be positive."""
-
-    def __init__(self, var: str | float) -> None:
-        """:param var: The variable that should be positive."""
-        super().__init__(f"{var} should be positive.")
-
+from gains.exceptions import ExpectPositiveError
 
 def window_equator(theta: np.ndarray, width: float, dtype: type) -> np.ndarray:
     """


### PR DESCRIPTION
Fixes #37 by adding a custom MeshError if the number of cpus requested is not a power of 2. Both custom exceptions currently used are put into `src/gains/exceptions.py` and imported, so they can be more easily called in future scripts.