### PR TITLE
Plot user selected coordinates.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ lint.ignore = [
   "D417",   # argument description in docstring (unreliable)
   "ISC001", # simplify implicit str concatenation (ruff-format recommended)
   "G004", # Logging statement uses f-string (Conflicts with a fix)
+  'PLR0913' # Does not allow more than 5 arguments
 ]
 lint.per-file-ignores = { "tests*" = [
   "D100",   # Missing docstring in public module

--- a/scripts/plot_spin_up.py
+++ b/scripts/plot_spin_up.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
 
     elif args["coordinate"] == "theta":
         path_list, fig = plot_against_time(
-            r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"]
+            theta, "theta", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"]
         )
         fig.savefig("{}/meridional_against_time.png".format(args["fig_dir"]))
 

--- a/scripts/plot_spin_up.py
+++ b/scripts/plot_spin_up.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     r = LabeledCoordinate(r_check, "r")
     theta = LabeledCoordinate(theta_check, "theta")
 
-    path_list, fig = plot_against_time(r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"])
+    path_list, fig = plot_against_time(r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"])
     fig.savefig("{}/radial_against_time.png".format(args["fig_dir"]))
 
     if anim_check == "y":

--- a/scripts/plot_spin_up.py
+++ b/scripts/plot_spin_up.py
@@ -66,10 +66,22 @@ if __name__ == "__main__":
     r = LabeledCoordinate(r_check, "r")
     theta = LabeledCoordinate(theta_check, "theta")
 
-    path_list, fig = plot_against_time(
-        r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"]
-    )
-    fig.savefig("{}/radial_against_time.png".format(args["fig_dir"]))
+    err_msg = "Coordinate varied must be r or theta."
+
+    if args["coordinate"] == "r":
+        path_list, fig = plot_against_time(
+            r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"]
+        )
+        fig.savefig("{}/radial_against_time.png".format(args["fig_dir"]))
+
+    elif args["coordinate"] == "theta":
+        path_list, fig = plot_against_time(
+            r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"]
+        )
+        fig.savefig("{}/meridional_against_time.png".format(args["fig_dir"]))
+
+    else:
+        raise NotImplementedError(err_msg)
 
     if anim_check == "y":
         num_files = len(path_list)

--- a/scripts/plot_spin_up.py
+++ b/scripts/plot_spin_up.py
@@ -66,7 +66,9 @@ if __name__ == "__main__":
     r = LabeledCoordinate(r_check, "r")
     theta = LabeledCoordinate(theta_check, "theta")
 
-    path_list, fig = plot_against_time(r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"])
+    path_list, fig = plot_against_time(
+        r, "r", path, PARAMS["Ek"], PARAMS["Ntheta"], args["targets"]
+    )
     fig.savefig("{}/radial_against_time.png".format(args["fig_dir"]))
 
     if anim_check == "y":

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -45,7 +45,7 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--targets",
         type=float,
-        nargs='*',
+        nargs="*",
         default=[0.5, 0.6, 0.7, 0.8, 0.9],
         help="The coordinate values you want to plot against time (The default "
         "assumes you are plotting different radii against time).",
@@ -368,7 +368,8 @@ def plot_against_time(
     :param path: The path to the output directory
     :param ek: The ekman number used in this run
     :param ntheta: The number of theta values.
-    :param targets: The values of the coordinate to measure the angular speed against time.
+    :param targets: The values of the coordinate to measure the angular speed
+    against time.
     :returns path_list: A list of only .h5 files in the specified path.
     """
     path = Path(path)

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -334,8 +334,8 @@ def plot_against_time(
 
     coord_val = coord.coord
     coord_name = coord.label
-
-    coord_tries = list(range(int(len(coord_val) / 2), len(coord_val), 6))
+    coord_res = len(coord_val)
+    coord_tries = np.arange(int(len(coord_val)/2), len(coord_val), int(0.05*coord_res))
     alphas = np.linspace(0.40, 1.0, len(coord_tries))
     coord_checked = [coord_val[i] for i in coord_tries]
 

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -50,6 +50,15 @@ def create_parser() -> argparse.ArgumentParser:
         "assumes you are plotting different radii against time).",
     )
 
+    parser.add_argument(
+        "--coordinate",
+        type=str,
+        default="r",
+        help="The coordinate to compare the spin up with time against "
+        "(ie vary the radial or angular location)."
+        " Takes r by default, pass theta to vary the meridional coordinate instead.",
+    )
+
     return parser
 
 

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -44,7 +44,8 @@ def create_parser() -> argparse.ArgumentParser:
 
     parser.add_argument(
         "--targets",
-        type=list,
+        type=float,
+        nargs='*',
         default=[0.5, 0.6, 0.7, 0.8, 0.9],
         help="The coordinate values you want to plot against time (The default "
         "assumes you are plotting different radii against time).",
@@ -314,9 +315,10 @@ def get_angular_speed_vs_time(
     Find the angular speed at the equator at a given radius.
 
     :param coord: The coordinate to be varied - should be r or theta.
-    :param c_get: Index of the coordinate we want.
+    :param target: Value of the coordinate we want.
     :param n_writes: Number of writes per .h5 file.
     :param path_list: List of paths to files to analyse.
+    :param ntheta: The number of theta values.
     :returns omega_rs: List of angular velocities at each time.
     :returns times: List of times data is saved at.
     """
@@ -364,10 +366,9 @@ def plot_against_time(
     :param coord: The coordinate and corrsponding label you want to vary when plotting.
     :param label: The label to appear on the legend.
     :param path: The path to the output directory
-    :param return_paths: Sets whether or not a list of paths to output files is
-    returned.
-    :param name: What to name the png file containing the figure.
-    :param targets: The values
+    :param ek: The ekman number used in this run
+    :param ntheta: The number of theta values.
+    :param targets: The values of the coordinate to measure the angular speed against time.
     :returns path_list: A list of only .h5 files in the specified path.
     """
     path = Path(path)

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -94,6 +94,21 @@ def my_interp2d(f: np.ndarray, rad: np.ndarray, radnew: np.ndarray) -> np.ndarra
     return fnew
 
 
+def get_arg_of_nearest(target: float, arr: np.ndarray) -> tuple[int, float]:
+    """
+    Return the nearest value to a target in an array, as well as its index.
+
+    :param target: The ideal value to search for in the array.
+    :param arr: The array to be searched for the target value.
+    :returns index: The index of the nearest value to target in the array.
+    :returns nearest: The closest value to the target in the array.
+    """
+    diff = np.abs(arr - target)
+    index = np.argmin(diff)
+    nearest = arr[index]
+    return index, nearest
+
+
 def plot_stream(
     r: np.ndarray,
     theta: np.ndarray,
@@ -272,7 +287,11 @@ def plot_angular_velocity(
 
 
 def get_angular_speed_vs_time(
-    coord: str, c_get: int, n_writes: int, path_list: list[Path], ntheta: int
+    coord: LabeledCoordinate,
+    target: float,
+    n_writes: int,
+    path_list: list[Path],
+    ntheta: int,
 ) -> np.ndarray:
     """
     Find the angular speed at the equator at a given radius.
@@ -285,21 +304,23 @@ def get_angular_speed_vs_time(
     :returns times: List of times data is saved at.
     """
     err_msg = "coordinate must be r or theta."
+
     out_size = len(path_list) * n_writes
     omega_rs = np.zeros((out_size,))
     times = np.zeros(out_size)
     theta_resolution = ntheta
     count = 0
+    c_get = get_arg_of_nearest(target, coord.coord)[0]
     for path in path_list:
         data = h5py.File(path, mode="r")
         time = np.array(data["scales/sim_time"])
         for j in range(n_writes):
             u_n_phi = data["tasks"]["u_n_phi"][j, -1, :, :]
-            if coord == "r":
+            if coord.label == "r":
                 omega_r = calculate_angular_speed_single(
                     path, c_get, int(theta_resolution / 2), u_n_phi
                 )  # theta arg esnures the equator is selected.
-            elif coord == "theta":
+            elif coord.label == "theta":
                 omega_r = calculate_angular_speed_single(
                     path, -1, c_get, u_n_phi
                 )  # r arg ensures the surface is selected.
@@ -332,27 +353,23 @@ def plot_against_time(
         (p for p in path.iterdir() if p.suffix == ".h5"), key=extract_numerical_suffix
     )
 
-    coord_val = coord.coord
-    coord_name = coord.label
-    coord_res = len(coord_val)
-    coord_tries = np.arange(int(len(coord_val)/2), len(coord_val), int(0.05*coord_res))
-    alphas = np.linspace(0.40, 1.0, len(coord_tries))
-    coord_checked = [coord_val[i] for i in coord_tries]
+    targets = [0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    alphas = np.linspace(0.40, 1.0, len(targets))
 
     fig = plt.figure()
     ax = fig.gca()
 
-    for i in range(len(coord_tries)):
-        val = coord_tries[i]
+    for i in range(len(targets)):
+        target = targets[i]
         omega_r, times = get_angular_speed_vs_time(
-            coord_name, val, 100, path_list, ntheta=ntheta
+            coord, target, 100, path_list, ntheta=ntheta
         )
         ax.plot(
             times,
             omega_r,
             color="#024cf7",
             alpha=alphas[i],
-            label=str(label + " = " + str(round(coord_checked[i], 2))),
+            label=str(label + " = " + str(round(target, 2))),
         )
     ax.legend(frameon=False, loc="lower right")
     t_ek = 1 / np.sqrt(ek)

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -42,6 +42,14 @@ def create_parser() -> argparse.ArgumentParser:
         help="The directory in which to save frames.",
     )
 
+    parser.add_argument(
+        "--targets",
+        type=list,
+        default=[0.5, 0.6, 0.7, 0.8, 0.9],
+        help="The coordinate values you want to plot against time (The default "
+        "assumes you are plotting different radii against time).",
+    )
+
     return parser
 
 
@@ -339,7 +347,7 @@ def plot_against_time(
     path: Path,
     ek: float,
     ntheta: int,
-    targets: np.array | list,
+    targets: np.ndarray | list,
 ) -> tuple[list[Path], mpl.figure]:
     """
     Plot a range of coordinate values against time.

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -334,7 +334,12 @@ def get_angular_speed_vs_time(
 
 
 def plot_against_time(
-    coord: LabeledCoordinate, label: str, path: Path, ek: float, ntheta: int
+    coord: LabeledCoordinate,
+    label: str,
+    path: Path,
+    ek: float,
+    ntheta: int,
+    targets: np.array | list,
 ) -> tuple[list[Path], mpl.figure]:
     """
     Plot a range of coordinate values against time.
@@ -345,6 +350,7 @@ def plot_against_time(
     :param return_paths: Sets whether or not a list of paths to output files is
     returned.
     :param name: What to name the png file containing the figure.
+    :param targets: The values
     :returns path_list: A list of only .h5 files in the specified path.
     """
     path = Path(path)
@@ -353,7 +359,6 @@ def plot_against_time(
         (p for p in path.iterdir() if p.suffix == ".h5"), key=extract_numerical_suffix
     )
 
-    targets = [0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
     alphas = np.linspace(0.40, 1.0, len(targets))
 
     fig = plt.figure()


### PR DESCRIPTION
Fixes #47 by plotting spin up of target coordinates provided by the user rather than the original calculation done in `plot_against_time` (which caused the amount plotted to vary with resolution). Other functions/command line options are added to facilitate this change, and the linting trigger for more than 5 function arguments is suppressed.