### PR TITLE
Adds optional time profiling to simulation code

### DIFF
--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -126,7 +126,7 @@ def profile(dirname: str | None) -> Callable:
 
             filename = output_dir / Path(f"time_profile.{comm.rank}")
             pr.dump_stats(filename)
-            
+
             return result
 
         return wrap_f
@@ -295,5 +295,6 @@ flow.add_property(np.sqrt(u_n @ u_n) * PARAMS["Ek"], name="Re_n")
 def evolve(solver: d3core.solvers.InitialValueSolver) -> None:
     """Call solver.evolve, but decorate with the profiling function."""
     return solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
+
 
 evolve(solver)

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -5,6 +5,7 @@ import cProfile
 import datetime
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 import dedalus.core as d3core
@@ -53,7 +54,8 @@ parser.add_argument(
     "--profile",
     type=str,
     default=None,
-    help="If an arg is provided, will also generate time profiling data, stored in a directory named as the"
+    help="If an arg is provided, will also generate time profiling data,"
+    " stored in a directory named as the"
     " argument provided.",
 )
 
@@ -82,7 +84,6 @@ cfl_safety = 0.2
 max_timestep = 1e-2
 dtype = np.float64
 comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
 ncpu = comm.size
 log2 = np.log2(ncpu)
 
@@ -94,11 +95,20 @@ else:
 logger.info(f"running on processor mesh={mesh}")
 
 
-def profile(dirname=None, comm=MPI.COMM_WORLD):
-    """Time profile the decorated function and save the result alongside with the outputs."""
+def profile(dirname: str | None) -> Callable:
+    """
+    Provide a decorator to use cProfile to profile an function running in parallel.
 
-    def prof_decorator(f):
-        def wrap_f(*args, **kwargs):
+    The stats are optionally saved in a subdirectory of the overall
+    output directory for the simulation, and saved using the dump_stats
+    method in a format readable by snakeviz.
+
+    :param dirname: The name of the directory to save the profiles to.
+    """
+    comm = MPI.COMM_WORLD
+
+    def prof_decorator(f: Callable) -> Callable:
+        def wrap_f(*args: object, **kwargs: object) -> object:
             pr = cProfile.Profile()
             pr.enable()
             result = f(*args, **kwargs)
@@ -108,12 +118,14 @@ def profile(dirname=None, comm=MPI.COMM_WORLD):
                 pr.print_stats()
             else:
                 output_dir = Path(f"outputs/{PARAMS['output_dir']}" + "/" + dirname)
-                if rank == 0:
+                # Only rank 0 creates directory to avoid race conditions
+                if comm.rank == 0:
                     output_dir.mkdir(parents=True, exist_ok=True)
+                # All ranks wait until directory exists
                 comm.Barrier()
 
-                filename_r = output_dir / Path(f"time_profile.{comm.rank}")
-                pr.dump_stats(filename_r)
+                filename = output_dir / Path(f"time_profile.{comm.rank}")
+                pr.dump_stats(filename)
             return result
 
         return wrap_f

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -296,9 +296,4 @@ def evolve(solver: d3core.solvers.InitialValueSolver) -> None:
     """Call solver.evolve, but decorate with the profiling function."""
     return solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
 
-
-if PARAMS["profile"] is not None:
-    evolve(solver)
-
-else:
-    solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
+evolve(solver)

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -117,7 +117,7 @@ def profile(dirname: str | None) -> Callable:
             if dirname is None:
                 pr.print_stats()
             else:
-                output_dir = Path(f"outputs/{PARAMS['output_dir']}" + "/" + dirname)
+                output_dir = Path("outputs") / PARAMS["output_dir"] / dirname
                 # Only rank 0 creates directory to avoid race conditions
                 if comm.rank == 0:
                     output_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -1,15 +1,16 @@
 """Simulates the spin up of a full sphere containing a viscous newtonian fluid."""
 
 import argparse
+import cProfile
 import datetime
 import json
 import logging
 from pathlib import Path
 
+import dedalus.core as d3core
 import dedalus.public as d3
 import numpy as np
 from mpi4py import MPI
-import cProfile
 
 from gains.exceptions import MeshError
 
@@ -48,6 +49,14 @@ parser.add_argument(
     help="relative path to parameter file to use for this run, saved in json format.",
 )
 
+parser.add_argument(
+    "--profile",
+    type=str,
+    default=None,
+    help="If an arg is provided, will also generate time profiling data, stored in a directory named as the"
+    " argument provided.",
+)
+
 args = vars(parser.parse_args())
 
 if args["parameter_file"] is not None:
@@ -65,13 +74,16 @@ PARAMS["output_dir"] = (
     else "single_spin_up_"
     + datetime.datetime.now().astimezone().strftime("%Y-%m-%m-%H:%M")
 )
+PARAMS["profile"] = args["profile"]
 # Additional Parameters - not likely to change between runs
 radius = 1
 timestepper = d3.SBDF2
 cfl_safety = 0.2
 max_timestep = 1e-2
 dtype = np.float64
-ncpu = MPI.COMM_WORLD.size
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+ncpu = comm.size
 log2 = np.log2(ncpu)
 
 if log2 == int(log2):
@@ -81,22 +93,33 @@ else:
 
 logger.info(f"running on processor mesh={mesh}")
 
-def profile(filename = None, comm = MPI.COMM_WORLD):
+
+def profile(dirname=None, comm=MPI.COMM_WORLD):
+    """Time profile the decorated function and save the result alongside with the outputs."""
+
     def prof_decorator(f):
-        def wrap_f(*args,**kwargs):
+        def wrap_f(*args, **kwargs):
             pr = cProfile.Profile()
             pr.enable()
-            result = f(*args,**kwargs)
+            result = f(*args, **kwargs)
             pr.disable()
 
-            if filename is None:
+            if dirname is None:
                 pr.print_stats()
             else:
-                filename_r = filename + ".{}".format(comm.rank)
+                output_dir = Path(f"outputs/{PARAMS['output_dir']}" + "/" + dirname)
+                if rank == 0:
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                comm.Barrier()
+
+                filename_r = output_dir / Path(f"time_profile.{comm.rank}")
                 pr.dump_stats(filename_r)
             return result
+
         return wrap_f
+
     return prof_decorator
+
 
 # Bases
 coords = d3.SphericalCoordinates("phi", "theta", "r")
@@ -254,13 +277,15 @@ CFL.add_velocity(u_n)
 flow = d3.GlobalFlowProperty(solver, cadence=10)
 flow.add_property(np.sqrt(u_n @ u_n) * PARAMS["Ek"], name="Re_n")
 
-@profile(filename="profile_test")
-def evolve(solver):
+
+@profile(dirname=PARAMS["profile"])
+def evolve(solver: d3core.solvers.InitialValueSolver) -> None:
+    """Call solver.evolve, but decorate with the profiling function."""
     return solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
 
-evolve(solver)
 
-'''
-# Main loop
-solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
-'''
+if PARAMS["profile"] is not None:
+    evolve(solver)
+
+else:
+    solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -107,6 +107,9 @@ def profile(dirname: str | None) -> Callable:
     """
     comm = MPI.COMM_WORLD
 
+    if dirname is None:
+        return lambda f: f
+
     def prof_decorator(f: Callable) -> Callable:
         def wrap_f(*args: object, **kwargs: object) -> object:
             pr = cProfile.Profile()
@@ -114,18 +117,16 @@ def profile(dirname: str | None) -> Callable:
             result = f(*args, **kwargs)
             pr.disable()
 
-            if dirname is None:
-                pr.print_stats()
-            else:
-                output_dir = Path("outputs") / PARAMS["output_dir"] / dirname
-                # Only rank 0 creates directory to avoid race conditions
-                if comm.rank == 0:
-                    output_dir.mkdir(parents=True, exist_ok=True)
-                # All ranks wait until directory exists
-                comm.Barrier()
+            output_dir = Path("outputs") / PARAMS["output_dir"] / dirname
+            # Only rank 0 creates directory to avoid race conditions
+            if comm.rank == 0:
+                output_dir.mkdir(parents=True, exist_ok=True)
+            # All ranks wait until directory exists
+            comm.Barrier()
 
-                filename = output_dir / Path(f"time_profile.{comm.rank}")
-                pr.dump_stats(filename)
+            filename = output_dir / Path(f"time_profile.{comm.rank}")
+            pr.dump_stats(filename)
+            
             return result
 
         return wrap_f

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import dedalus.public as d3
 import numpy as np
 from mpi4py import MPI
+import cProfile
 
 from gains.exceptions import MeshError
 
@@ -80,6 +81,22 @@ else:
 
 logger.info(f"running on processor mesh={mesh}")
 
+def profile(filename = None, comm = MPI.COMM_WORLD):
+    def prof_decorator(f):
+        def wrap_f(*args,**kwargs):
+            pr = cProfile.Profile()
+            pr.enable()
+            result = f(*args,**kwargs)
+            pr.disable()
+
+            if filename is None:
+                pr.print_stats()
+            else:
+                filename_r = filename + ".{}".format(comm.rank)
+                pr.dump_stats(filename_r)
+            return result
+        return wrap_f
+    return prof_decorator
 
 # Bases
 coords = d3.SphericalCoordinates("phi", "theta", "r")
@@ -150,7 +167,7 @@ problem = d3.IVP([p_n, u_n, tau_p_n, tau_u_n], namespace=locals())
 problem.add_equation("div(u_n) + tau_p_n = 0")
 problem.add_equation(
     "dt(u_n) + grad(p_n) - Ek*lap(u_n) + lift(tau_u_n)  = -u_n@grad(u_n) "
-    "-2*cross(ez,u_n) - cross(curl(u_n),u_n)"
+    "-2*cross(ez,u_n)"
 )
 problem.add_equation(
     "angular(u_n(r=radius)) = mask*angular(uang_r1) + (1-mask)*angular(u_n(r=radius))"
@@ -237,5 +254,13 @@ CFL.add_velocity(u_n)
 flow = d3.GlobalFlowProperty(solver, cadence=10)
 flow.add_property(np.sqrt(u_n @ u_n) * PARAMS["Ek"], name="Re_n")
 
+@profile(filename="profile_test")
+def evolve(solver):
+    return solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
+
+evolve(solver)
+
+'''
 # Main loop
 solver.evolve(timestep_function=CFL.compute_timestep, log_cadence=10)
+'''


### PR DESCRIPTION
Fixes #51 by adding a method to profile the main loop of the dedalus solver.

A function decorator `prof_decorator` was defined in the spin up script, and a command line option was created to choose if profile data should be saved or not. Separate profiles are saved for each mpi rank, and can be visualised using the snakeviz tool.