### PR TITLE
Addition of a utils module

### DIFF
--- a/scripts/plot_spin_up.py
+++ b/scripts/plot_spin_up.py
@@ -11,18 +11,18 @@ import numpy as np
 
 from gains.analysis.analyse_spin_up import (
     LabeledCoordinate,
-    create_parser,
     get_angular_coords,
     plot_against_time,
     plot_angular_velocity,
 )
 from gains.params.single_spin_up_rotating import parameters as default_params
+from gains.utils import create_parser_analysis
 
 warnings.filterwarnings("ignore")
 logging.basicConfig(level=logging.INFO)
 
 if __name__ == "__main__":
-    parser = create_parser()
+    parser = create_parser_analysis()
     args = vars(parser.parse_args())
 
     if args["parameter_file"] is not None:

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -1,6 +1,5 @@
 """Simulates the spin up of a full sphere containing a viscous newtonian fluid."""
 
-import argparse
 import cProfile
 import datetime
 import json
@@ -14,11 +13,11 @@ import numpy as np
 from mpi4py import MPI
 
 from gains.exceptions import MeshError
-from gains.utils import create_parser_simulation
 
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
 from gains.params.single_spin_up_rotating import parameters as default_params
+from gains.utils import create_parser_simulation
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/single_spin_up_rotating_frame.py
+++ b/scripts/single_spin_up_rotating_frame.py
@@ -14,6 +14,7 @@ import numpy as np
 from mpi4py import MPI
 
 from gains.exceptions import MeshError
+from gains.utils import create_parser_simulation
 
 # Parameters - load in from parameter file
 from gains.initial_conditions.single_component_spin_up import window_equator
@@ -21,43 +22,7 @@ from gains.params.single_spin_up_rotating import parameters as default_params
 
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser(
-    description="Simulate a localised spin up on the surface of a sphere of fluid."
-)
-
-parser.add_argument(
-    "--use_checkpoint",
-    type=bool,
-    default=False,
-    help="Boolean argument to determine if to use a checkpoint file.",
-)
-
-parser.add_argument(
-    "--checkpoint_path",
-    type=str,
-    default="outputs/checkpoints/checkpoints_sNumber.h5",
-    help="Path to the checkpoint file you want to use.",
-)
-
-parser.add_argument(
-    "--output_dir", type=str, default=None, help="Directory to store simulation outputs"
-)
-
-parser.add_argument(
-    "--parameter_file",
-    type=Path,
-    default=None,
-    help="relative path to parameter file to use for this run, saved in json format.",
-)
-
-parser.add_argument(
-    "--profile",
-    type=str,
-    default=None,
-    help="If an arg is provided, will also generate time profiling data,"
-    " stored in a directory named as the"
-    " argument provided.",
-)
+parser = create_parser_simulation()
 
 args = vars(parser.parse_args())
 

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -9,6 +9,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.interpolate as inp
+from gains.utils import get_arg_of_nearest
 
 
 class LabeledCoordinate:
@@ -58,21 +59,6 @@ def my_interp2d(f: np.ndarray, rad: np.ndarray, radnew: np.ndarray) -> np.ndarra
         fnew[i, :] = spl_rep(radnew)
 
     return fnew
-
-
-def get_arg_of_nearest(target: float, arr: np.ndarray) -> tuple[int, float]:
-    """
-    Return the nearest value to a target in an array, as well as its index.
-
-    :param target: The ideal value to search for in the array.
-    :param arr: The array to be searched for the target value.
-    :returns index: The index of the nearest value to target in the array.
-    :returns nearest: The closest value to the target in the array.
-    """
-    diff = np.abs(arr - target)
-    index = np.argmin(diff)
-    nearest = arr[index]
-    return index, nearest
 
 
 def plot_stream(

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -1,6 +1,5 @@
 """Contains functions to produce plots in scripts/plot_spin_up.py."""
 
-import argparse
 import re
 from pathlib import Path
 
@@ -9,6 +8,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.interpolate as inp
+
 from gains.utils import get_arg_of_nearest
 
 

--- a/src/gains/Analysis/analyse_spin_up.py
+++ b/src/gains/Analysis/analyse_spin_up.py
@@ -11,58 +11,6 @@ import numpy as np
 import scipy.interpolate as inp
 
 
-def create_parser() -> argparse.ArgumentParser:
-    """Create parser for command line arguments in plotting code."""
-    parser = argparse.ArgumentParser(
-        description="Full analysis of a single component spin up simulation"
-    )
-    parser.add_argument(
-        "--parameter_file",
-        type=str,
-        default=None,
-        help="relative path to parameter file to use for this run,"
-        " saved in json format.",
-    )
-
-    parser.add_argument(
-        "output_dir", type=str, default=None, help="Path to output directory."
-    )
-
-    parser.add_argument(
-        "--fig_dir",
-        type=str,
-        default="outputs",
-        help="The directory in which to save figures.",
-    )
-
-    parser.add_argument(
-        "--frame_dir",
-        type=str,
-        default="frames",
-        help="The directory in which to save frames.",
-    )
-
-    parser.add_argument(
-        "--targets",
-        type=float,
-        nargs="*",
-        default=[0.5, 0.6, 0.7, 0.8, 0.9],
-        help="The coordinate values you want to plot against time (The default "
-        "assumes you are plotting different radii against time).",
-    )
-
-    parser.add_argument(
-        "--coordinate",
-        type=str,
-        default="r",
-        help="The coordinate to compare the spin up with time against "
-        "(ie vary the radial or angular location)."
-        " Takes r by default, pass theta to vary the meridional coordinate instead.",
-    )
-
-    return parser
-
-
 class LabeledCoordinate:
     """Holds a coordinate (for example r or theta) and its name for use in plotting."""
 

--- a/src/gains/utils.py
+++ b/src/gains/utils.py
@@ -2,6 +2,7 @@
 
 import argparse
 import cProfile
+import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -151,3 +152,19 @@ def get_arg_of_nearest(target: float, arr: np.ndarray) -> tuple[int, float]:
     index = np.argmin(diff)
     nearest = arr[index]
     return index, nearest
+
+
+def extract_numerical_suffix(path: Path) -> int | float:
+    """
+    Extract an integer at the end of a filename.
+
+    Takes a path to a file saved in the form /output_dir/file_name[num].extension
+    and return num. Files that don't fit this format will be assigned inf, so
+    placed at the end of a list when sorting.
+
+    :param path: path to the output file, in the form
+    /output_dir/file_name[num].extension.
+    :returns suffix: Integer at the end of the file name.
+    """
+    match = re.search(r"(\d+)$", path.stem)
+    return int(match.group(1)) if match else float("inf")

--- a/src/gains/utils.py
+++ b/src/gains/utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from collections.abc import Callable
 import cProfile
 from mpi4py import MPI
+import numpy as np
 
 def create_parser_simulation() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -125,3 +126,17 @@ def profile(dirname: str | None, PARAMS: dict) -> Callable:
         return wrap_f
 
     return prof_decorator
+
+def get_arg_of_nearest(target: float, arr: np.ndarray) -> tuple[int, float]:
+    """
+    Return the nearest value to a target in an array, as well as its index.
+
+    :param target: The ideal value to search for in the array.
+    :param arr: The array to be searched for the target value.
+    :returns index: The index of the nearest value to target in the array.
+    :returns nearest: The closest value to the target in the array.
+    """
+    diff = np.abs(arr - target)
+    index = np.argmin(diff)
+    nearest = arr[index]
+    return index, nearest

--- a/src/gains/utils.py
+++ b/src/gains/utils.py
@@ -36,6 +36,58 @@ def create_parser_simulation() -> argparse.ArgumentParser:
 
     return parser
 
+def create_parser_analysis() -> argparse.ArgumentParser:
+    """Create parser for command line arguments in plotting code."""
+    
+    parser = argparse.ArgumentParser(
+        description="Full analysis of a single component spin up simulation"
+    )
+    parser.add_argument(
+        "--parameter_file",
+        type=str,
+        default=None,
+        help="relative path to parameter file to use for this run,"
+        " saved in json format.",
+    )
+
+    parser.add_argument(
+        "output_dir", type=str, default=None, help="Path to output directory."
+    )
+
+    parser.add_argument(
+        "--fig_dir",
+        type=str,
+        default="outputs",
+        help="The directory in which to save figures.",
+    )
+
+    parser.add_argument(
+        "--frame_dir",
+        type=str,
+        default="frames",
+        help="The directory in which to save frames.",
+    )
+
+    parser.add_argument(
+        "--targets",
+        type=float,
+        nargs="*",
+        default=[0.5, 0.6, 0.7, 0.8, 0.9],
+        help="The coordinate values you want to plot against time (The default "
+        "assumes you are plotting different radii against time).",
+    )
+
+    parser.add_argument(
+        "--coordinate",
+        type=str,
+        default="r",
+        help="The coordinate to compare the spin up with time against "
+        "(ie vary the radial or angular location)."
+        " Takes r by default, pass theta to vary the meridional coordinate instead.",
+    )
+
+    return parser
+
 def profile(dirname: str | None, PARAMS: dict) -> Callable:
     """
     Provide a decorator to use cProfile to profile an function running in parallel.

--- a/src/gains/utils.py
+++ b/src/gains/utils.py
@@ -1,0 +1,75 @@
+import argparse
+from pathlib import Path
+from collections.abc import Callable
+import cProfile
+from mpi4py import MPI
+
+def create_parser_simulation() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description='simulate glitch on the boundary of a spherical star'
+    )
+
+    parser.add_argument(
+        "--use_checkpoint",
+        type=bool,
+        default=False,
+        help="Boolean argument to determine if to use a checkpoint file.",
+    )
+
+    parser.add_argument(
+        "--checkpoint_path",
+        type=str,
+        default="outputs/checkpoints/checkpoints_sNumber.h5",
+        help="Path to the checkpoint file you want to use.",
+    )
+
+    parser.add_argument(
+        "--output_dir", type=str, default=None, help="Directory to store simulation outputs"
+    )
+
+    parser.add_argument(
+        "--parameter_file",
+        type=Path,
+        default=None,
+        help="relative path to parameter file to use for this run, saved in json format.",
+    )
+
+    return parser
+
+def profile(dirname: str | None, PARAMS: dict) -> Callable:
+    """
+    Provide a decorator to use cProfile to profile an function running in parallel.
+
+    The stats are optionally saved in a subdirectory of the overall
+    output directory for the simulation, and saved using the dump_stats
+    method in a format readable by snakeviz.
+
+    :param dirname: The name of the directory to save the profiles to.
+    """
+    comm = MPI.COMM_WORLD
+
+    if dirname is None:
+        return lambda f: f
+
+    def prof_decorator(f: Callable) -> Callable:
+        def wrap_f(*args: object, **kwargs: object) -> object:
+            pr = cProfile.Profile()
+            pr.enable()
+            result = f(*args, **kwargs)
+            pr.disable()
+
+            output_dir = Path("outputs") / PARAMS["output_dir"] / dirname
+            # Only rank 0 creates directory to avoid race conditions
+            if comm.rank == 0:
+                output_dir.mkdir(parents=True, exist_ok=True)
+            # All ranks wait until directory exists
+            comm.Barrier()
+
+            filename = output_dir / Path(f"time_profile.{comm.rank}")
+            pr.dump_stats(filename)
+
+            return result
+
+        return wrap_f
+
+    return prof_decorator

--- a/src/gains/utils.py
+++ b/src/gains/utils.py
@@ -1,13 +1,18 @@
+"""Stores useful functions, applicable throughout the package."""
+
 import argparse
-from pathlib import Path
-from collections.abc import Callable
 import cProfile
-from mpi4py import MPI
+from collections.abc import Callable
+from pathlib import Path
+
 import numpy as np
+from mpi4py import MPI
+
 
 def create_parser_simulation() -> argparse.ArgumentParser:
+    """Create argument parser for simulations in a rotating spherical star."""
     parser = argparse.ArgumentParser(
-        description='simulate glitch on the boundary of a spherical star'
+        description="simulate glitch on the boundary of a spherical star"
     )
 
     parser.add_argument(
@@ -25,21 +30,25 @@ def create_parser_simulation() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--output_dir", type=str, default=None, help="Directory to store simulation outputs"
+        "--output_dir",
+        type=str,
+        default=None,
+        help="Directory to store simulation outputs",
     )
 
     parser.add_argument(
         "--parameter_file",
         type=Path,
         default=None,
-        help="relative path to parameter file to use for this run, saved in json format.",
+        help="relative path to parameter file to use for this run, saved in"
+        " json format.",
     )
 
     return parser
 
+
 def create_parser_analysis() -> argparse.ArgumentParser:
     """Create parser for command line arguments in plotting code."""
-    
     parser = argparse.ArgumentParser(
         description="Full analysis of a single component spin up simulation"
     )
@@ -89,7 +98,8 @@ def create_parser_analysis() -> argparse.ArgumentParser:
 
     return parser
 
-def profile(dirname: str | None, PARAMS: dict) -> Callable:
+
+def profile(dirname: str | None, params: dict) -> Callable:
     """
     Provide a decorator to use cProfile to profile an function running in parallel.
 
@@ -111,7 +121,7 @@ def profile(dirname: str | None, PARAMS: dict) -> Callable:
             result = f(*args, **kwargs)
             pr.disable()
 
-            output_dir = Path("outputs") / PARAMS["output_dir"] / dirname
+            output_dir = Path("outputs") / params["output_dir"] / dirname
             # Only rank 0 creates directory to avoid race conditions
             if comm.rank == 0:
                 output_dir.mkdir(parents=True, exist_ok=True)
@@ -126,6 +136,7 @@ def profile(dirname: str | None, PARAMS: dict) -> Callable:
         return wrap_f
 
     return prof_decorator
+
 
 def get_arg_of_nearest(target: float, arr: np.ndarray) -> tuple[int, float]:
     """


### PR DESCRIPTION
Fixes #50 by creating a `gains.utils` module. This may be slightly earlier than expected, but I found myself using something similar in the two fluid branch, so it seemed sensible to get this done sooner rather than later. The module contains the argument parsers, the profile decorator,`get_arg_of_nearest` and `extract_numerical_suffix`.