### PR TITLE
Add checkpointing to simulation CLI

### DIFF
--- a/src/gains/utils/parsers.py
+++ b/src/gains/utils/parsers.py
@@ -98,7 +98,7 @@ class SimulationCLI(argparse.ArgumentParser):
             "--checkpoint_cadence",
             type=int,
             default=3600,
-            help="Time in seconds between checkpoint saves."
+            help="Time in seconds between checkpoint saves.",
         )
 
     def _default_dir_name(self) -> str:
@@ -153,7 +153,7 @@ class SimulationCLI(argparse.ArgumentParser):
         params["use_checkpoint"] = parsed_args["use_checkpoint"]
         params["checkpoint_path"] = parsed_args["checkpoint_path"]
         params["profile"] = parsed_args.get("profile")
-        params["checkpoint_cadence"]=parsed_args["checkpoint_cadence"]
+        params["checkpoint_cadence"] = parsed_args["checkpoint_cadence"]
 
         params["output_dir"] = self.place_all_outputs_under / (
             parsed_args["output_dir"]

--- a/src/gains/utils/parsers.py
+++ b/src/gains/utils/parsers.py
@@ -94,6 +94,12 @@ class SimulationCLI(argparse.ArgumentParser):
             default=None,
             help="Name of logfile, if you want to create one.",
         )
+        self.add_argument(
+            "--checkpoint_cadence",
+            type=int,
+            default=3600,
+            help="Time in seconds between checkpoint saves."
+        )
 
     def _default_dir_name(self) -> str:
         """Generate a default name for an output directory."""
@@ -147,6 +153,7 @@ class SimulationCLI(argparse.ArgumentParser):
         params["use_checkpoint"] = parsed_args["use_checkpoint"]
         params["checkpoint_path"] = parsed_args["checkpoint_path"]
         params["profile"] = parsed_args.get("profile")
+        params["checkpoint_cadence"]=parsed_args["checkpoint_cadence"]
 
         params["output_dir"] = self.place_all_outputs_under / (
             parsed_args["output_dir"]

--- a/tests/test_utils/test_simulation_parser.py
+++ b/tests/test_utils/test_simulation_parser.py
@@ -171,6 +171,7 @@ def test_simulation_cli_parsing(
             "output_dir", parser.place_all_outputs_under / parser._default_output_dir
         )
         expected_output.setdefault("profile", None)
+        expected_output.setdefault("checkpoint_cadence", 3600)
 
         params = parser.parse_args_and_get_params(
             logger_for_tests, cli_args, default_params=default_params


### PR DESCRIPTION
Adds the `checkpoint_cadence` option to the `SimulationCLI` class. An example use in a simulation script would be:

```python
checkpoint = solver.evaluator.add_file_handler(PARAMS["output_dir"] / "checkpoint", wall_dt=PARAMS["checkpoint_cadence"], max_writes=1, parallel='gather')
checkpoint.add_tasks(solver.state, layout='g')
```

